### PR TITLE
ccblc cleanup

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,5 +26,4 @@ dependencies:
   - shapely
   - pip
   - pip:
-    - -r requirements.txt
-    - .
+    - -e .

--- a/notebooks/development-unmixing.ipynb
+++ b/notebooks/development-unmixing.ipynb
@@ -34,15 +34,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext ccblc"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# authenticate earth engine api access (not required on every run)\n",
     "ee.Authenticate()"
    ]
@@ -84,14 +75,14 @@
    "outputs": [],
    "source": [
     "# select the sensor to use\n",
-    "sensor = 'Landsat8'\n",
+    "sensor = 'Sentinel2'\n",
     "collectionName = eli.getCollection(sensor)\n",
     "bands = eli.getBands(sensor)\n",
     "scaler = eli.getScaler(sensor)\n",
     "maskFunction = eli.Mask.bySensor(sensor)\n",
-    "visBands = [\"B6\", \"B5\", \"B4\"]\n",
-    "#visBands = [\"sur_refl_b06\", \"sur_refl_b05\", \"sur_refl_b01\"]\n",
-    "#visBands = [\"B11\", \"B5\", \"B4\"]\n",
+    "#visBands = [\"B6\", \"B5\", \"B4\"] # Landsat-8\n",
+    "#visBands = [\"sur_refl_b06\", \"sur_refl_b05\", \"sur_refl_b01\"] # MODIS\n",
+    "visBands = [\"B11\", \"B5\", \"B4\"] # Sentinel-2\n",
     "\n",
     "# set the dates\n",
     "startDate = \"2020-03-01\";\n",
@@ -158,7 +149,6 @@
     "\n",
     "# unmix the thing\n",
     "unmixed = eli.Unmix.SVN(sr).updateMask(land)\n",
-    "#unmixed = collection.map(ccblc.Unmix.SVN).mean()\n",
     "\n",
     "# map it\n",
     "visParams = {'min': [0, 0.1, 0], 'max': [0.8, 1, 0.8]}\n",


### PR DESCRIPTION
This PR contains no associated issue, but it addresses a couple of small outstanding enhancements.

First, it updates the conda environment to use `pip install -e .` for installing the local version of `earthlib`. This is important because it means the changes you make to your local code will be available every time you use `import earthlib` after making a change. 

Better yet, when working with this code in jupyter notebooks, by using the following two lines (which are also implemented in `notebooks/development-unmixing.ipynb `), you'll automatically reload the changes you make to your local code without having to re-run any notebook blocks.

```python
%load_ext autoreload
%autoreload 2
```

The second updates below remove an old code block used for manually reloading extensions (which is no longer necessary), and I added some comments clarifying which sensor each version of `visBands` referred to.