### PR TITLE
Sentinel-2 qa band masking

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,12 @@
 
 `earthlib` is a spectral library and a set of software tools for satellite-base land cover mapping.
 
-The spectral library contains several thousand unique spectral endmembers representing green vegetation, soil, non-photosynthetic vegetation, urban materials, and char. The reflectance data cover the visible to the shortwave infrared wavelengths (400-2450 nm) at 10 nm band widths.
+The library contains several thousand unique spectral endmembers representing green vegetation, soil, non-photosynthetic vegetation, urban materials, and burned materials. The reflectance data cover the visible to the shortwave infrared wavelengths (400-2450 nm) at 10 nm band widths.
 
-The software tools i) resample these data to match the wavelenths of popular satellite and airborne earth observing sensors and ii) run spectral mixture analysis in Google Earth Engine via the `earthengine` python package.
+The software tools (1) resample these data to match the wavelenths of popular satellite and airborne earth observing sensors and (2) run spectral mixture analysis in Google Earth Engine via the `earthengine` python package.
 
-The goal is to quantify spatial and temporal patterns of change in global vegetation cover, as well as patterns of soil cover, burned area, non-photosynthetic vegetation, and impervious surfaces. With `earthlib`, you can do this using any satellite data source.
+The goal is to quantify spatial and temporal patterns of change in global vegetation cover, as well as patterns of soil cover, burned area, non-photosynthetic vegetation, and impervious surfaces. With `earthlib`, you can do this using most public satellite data sources.
 
-This work is still in development and has not yet been formally described.
-
-### Table of Contents
-
-- [Installation](#installation)
-- [Contact](#contact)
 
 # Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,30 +14,11 @@
 
 `earthlib` is a spectral library and a set of software tools for satellite-base land cover mapping.
 
-The spectral library contains several thousand unique spectral endmembers representing green vegetation, soil, non-photosynthetic vegetation, urban materials, and char. The reflectance data cover the visible to the shortwave infrared wavelengths (400-2450 nm) at 10 nm band widths.
+The library contains several thousand unique spectral endmembers representing green vegetation, soil, non-photosynthetic vegetation, urban materials, and burned materials. The reflectance data cover the visible to the shortwave infrared wavelengths (400-2450 nm) at 10 nm band widths.
 
-The software tools i) resample these data to match the wavelenths of popular satellite and airborne earth observing sensors and ii) run spectral mixture analysis in Google Earth Engine via the `earthengine` python package.
+The software tools (1) resample these data to match the wavelenths of popular satellite and airborne earth observing sensors and (2) run [spectral mixture analysis](introduction.md) in Google Earth Engine via the `earthengine` python package.
 
-The goal is to quantify spatial and temporal patterns of change in global vegetation cover, as well as patterns of soil cover, burned area, non-photosynthetic vegetation, and impervious surfaces. With `earthlib`, you can do this using any satellite data source.
-
-This work is still in active development.
-
-### Table of Contents
-
-- [Spectral mixture analysis](#spectral-mixture-analysis)
-- [Installation](#installation)
-- [Contact](#contact)
-
-
-# Spectral mixture analysis
-
-The contents of a satellite image pixel are rarely homogeneous. An area 30x30m in size can include buildings, trees, and roads in urban environments; grasses, soils, and char in recently burned landscapes; trees, gaps, and downed logs in forested areas. These patterns all affect the reflectance patterns measured by satellites, and it's important to be able to estimate the sub-pixel abundances of each of these land cover types.
-
-![earthlib spectral mixture analysis](img/sma-basics.png)
-
-Spectral mixture analysis is an approach to estimating the sub-pixel contents of an image pixel based on a set of representaive reflectance spectra (i.e., a reference library). Linear spectral mixture analysis uses an iterative, least-squares fitting approach to estimate the proportions of land cover types based on observed reflectance measurements. In order to run these analyses, you need 1) a high quality reference library of different land cover types, and 2) to resample these reference data to the wavelengths of the instrument you plan to analyze.
-
-To support these analysise, `earthlib` provides a rich spectral library with thousands of [labeled reference spectra](sources.md) and tools for working with common satellite instruments.
+The goal is to quantify spatial and temporal patterns of change in global vegetation cover, as well as patterns of soil cover, burned area, non-photosynthetic vegetation, and impervious surfaces. With `earthlib`, you can do this using most public satellite [data sources](sources.md).
 
 
 # Installation

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,9 @@
+# Spectral Mixture Analysis
+
+The contents of a satellite image pixel are rarely homogeneous. An area 30x30m in size can include buildings, trees, and roads in urban environments; grasses, soils, and char in recently burned landscapes; trees, gaps, and downed logs in forested areas. These patterns all affect the reflectance patterns measured by satellites, and it's important to be able to estimate the sub-pixel abundances of each of these land cover types.
+
+![earthlib spectral mixture analysis](img/sma-basics.png)
+
+Spectral mixture analysis is an approach to estimating the sub-pixel contents of an image pixel based on a set of representaive reflectance spectra (i.e., a reference library). Linear spectral mixture analysis uses an iterative, least-squares fitting approach to estimate the proportions of land cover types based on observed reflectance measurements. In order to run these analyses, you need 1) a high quality reference library of different land cover types, and 2) to resample these reference data to the wavelengths of the instrument you plan to analyze.
+
+To support these analysise, `earthlib` provides a rich spectral library with thousands of [labeled reference spectra](sources.md) and tools for working with common satellite instruments.

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -1,9 +1,9 @@
 # Data Sources
 
-The Earth Library is a collection of collections, merging spectral measurments and models from a range of raw data sources. `earthlib` provides routines for resampling this collection to match the wavelenghts of the sensors in the series above.
+The Earth Library is a collection of collections, merging spectral measurments and models from a range of data sources. `earthlib` provides routines for resampling this collection to match the wavelenghts of many common optical imaging sensors.
 
 
-## Spectral Libraries
+## Spectral libraries
 
 The following data sources were filtered and resampled prior to inclusion in `earthlib`.
 
@@ -13,6 +13,7 @@ The following data sources were filtered and resampled prior to inclusion in `ea
 - UCSB's [Urban Reflectance Spectra](https://ecosis.org/package/urban-reflectance-spectra-from-santa-barbara--ca)
 - UW/BNL/NASA HySPIRI [airborne calibration spectra](https://ecosis.org/package/uw-bnl-nasa-hyspiri-airborne-campaign-leaf-and-canopy-spectra-and-trait-data)
 - [USGS Spectral Library Version 7](https://www.sciencebase.gov/catalog/item/5807a2a2e4b0841e59e3a18d)
+
 
 Below are plots for the primary land cover spectra included in `earthlib`.
 
@@ -25,6 +26,7 @@ Below are plots for the primary land cover spectra included in `earthlib`.
 ![earthlib burned spectra](img/spectra-burn-mean-stdv.png)
 
 ![earthlib vegetation spectra](img/spectra-urban-mean-stdv.png)
+
 
 ## Supported sensors
 

--- a/earthlib/Mask.py
+++ b/earthlib/Mask.py
@@ -35,8 +35,8 @@ def Sentinel2(img):
     cirrusBitMask = _ee.Number(2).pow(11).int()
     cloudsBitMask = _ee.Number(2).pow(10).int()
     qa = img.select("QA60")
-    mask = qa.bitwiseAnd(cirrusBitMask).eq(0).And(qa.bitwiseAnd(cloudsBitMask).eq(0))
-    return img.mask(mask)
+    mask = qa.bitwiseAnd(cloudsBitMask).eq(0).And(qa.bitwiseAnd(cirrusBitMask).eq(0))
+    return img.updateMask(mask)
 
 
 def MODIS(img):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ extra:
 # site navigation
 nav:
     - Home: 'index.md'
+    - Introduction: 'introduction.md'
     - Data Sources: 'sources.md'
     - Code Documentation:
         - earthlib.Map: 'module/Map.md'


### PR DESCRIPTION
Fixes #7 

The Sentinel-2 masking was anomalously masking valid image values. It's unclear why, but changing from `img.mask()` to `img.updateMask()` resolved this. Hooray!

This PR also contains some very minor edits to one of the documentation pages. This can be ignored.