### PR TITLE
Include stricter cloud masking thresholds

### DIFF
--- a/docs/module/ThresholdMask.md
+++ b/docs/module/ThresholdMask.md
@@ -1,0 +1,1 @@
+::: earthlib.ThresholdMask

--- a/earthlib/BrightMask.py
+++ b/earthlib/BrightMask.py
@@ -61,7 +61,10 @@ def Landsat457(img: ee.Image, threshold: float = 0.4) -> ee.Image:
     Returns:
         the same input image with an updated mask.
     """
-    subset = img.select(getBands("Landsat7"))
+    # remove SWIR2 band where most ground/cloud confusion occurs
+    bands = getBands("Landsat7")
+    bands.remove("SR_B7")
+    subset = img.select()
     shade = brightMask(subset, threshold)
     return img.updateMask(shade)
 
@@ -77,12 +80,14 @@ def Landsat8(img: ee.Image, threshold: float = 0.4) -> ee.Image:
     Returns:
         the same input image with an updated mask.
     """
-    subset = img.select(getBands("Landsat8"))
+    bands = getBands("Landsat8")
+    bands.remove("SR_B7")
+    subset = img.select(bands)
     shade = brightMask(subset, threshold)
     return img.updateMask(shade)
 
 
-def MODIS(img: ee.Image, threshold: float = 0.45) -> ee.Image:
+def MODIS(img: ee.Image, threshold: float = 0.4) -> ee.Image:
     """Apply bright pixel masking to a MODIS image.
 
     Args:
@@ -93,6 +98,8 @@ def MODIS(img: ee.Image, threshold: float = 0.45) -> ee.Image:
     Returns:
         the same input image with an updated mask.
     """
-    subset = img.select(getBands("MODIS"))
+    bands = getBands("MODIS")
+    bands.remove("sur_refl_b07")
+    subset = img.select(bands)
     shade = brightMask(subset, threshold)
     return img.updateMask(shade)

--- a/earthlib/CloudMask.py
+++ b/earthlib/CloudMask.py
@@ -34,10 +34,10 @@ def bySensor(sensor: str) -> Callable:
         the mask function associated with a sensor to pass to an ee .map() call
     """
     lookup = {
-        "Landsat4": Landsat4578,
-        "Landsat5": Landsat4578,
-        "Landsat7": Landsat4578,
-        "Landsat8": Landsat4578,
+        "Landsat4": Landsat457,
+        "Landsat5": Landsat457,
+        "Landsat7": Landsat457,
+        "Landsat8": Landsat8,
         "Sentinel2": Sentinel2,
         "MODIS": MODIS,
         "VIIRS": VIIRS,
@@ -52,14 +52,58 @@ def bySensor(sensor: str) -> Callable:
         )
 
 
-def Landsat4578(img: ee.Image) -> ee.Image:
-    """Cloud-mask Landsat images.
+def Landsat457(
+    img: ee.Image, use_qa: bool = True, use_thresholds: bool = True
+) -> ee.Image:
+    """Cloud-mask Landsat 4/5/7 images using multiple methods.
+
+    Args:
+        img: the ee.Image to mask.
+        use_qa: mask with the Landsat QA band.
+        use_thresholds: mask with a series of band thresholds.
+
+    Returns:
+        the same input image with an updated mask.
+    """
+    if use_qa:
+        img = Landsat4578QA(img)
+
+    if use_thresholds:
+        img = Landsat457Threshold(img)
+
+    return img
+
+
+def Landsat8(
+    img: ee.Image, use_qa: bool = True, use_thresholds: bool = True
+) -> ee.Image:
+    """Cloud-mask Landsat 8 images using multiple methods.
+
+    Args:
+        img: the ee.Image to mask. Must have a Landsat "QA_PIXEL" band.
+        use_qa: mask with the Landsat QA band.
+        use_thresholds: mask with a series of band thresholds.
+
+    Returns:
+        the same input image with an updated mask.
+    """
+    if use_qa:
+        img = Landsat4578QA(img)
+
+    if use_thresholds:
+        img = Landsat8Threshold(img)
+
+    return img
+
+
+def Landsat4578QA(img: ee.Image) -> ee.Image:
+    """Cloud-mask Landsat images based on the QA bands.
 
     See https://gis.stackexchange.com/questions/349371/creating-cloud-free-images-out-of-a-mod09a1-modis-image-in-gee
     Previously: https://gis.stackexchange.com/questions/425159/how-to-make-a-cloud-free-composite-for-landsat-8-collection-2-surface-reflectanc/425160
 
     Args:
-        img: the ee.Image to mask. Must have a Landsat "QA_PIXEL" band.
+        img: the ee.Image to mask. Must have Landsat "QA_PIXEL" and "QA_RADSAT" band.
 
     Returns:
         the same input image with an updated mask.
@@ -78,6 +122,121 @@ def Landsat4578(img: ee.Image) -> ee.Image:
     jointMask = qaMask.And(satMask)
 
     return img.updateMask(jointMask)
+
+
+def Landsat457Threshold(img: ee.Image, probability_threshold: float = 0.4) -> ee.Image:
+    """Compute cloud probability using a series of band ratios and apply a mask threshold.
+
+    See Sun & Tian 2017: https://www.sciencedirect.com/science/article/pii/S0924271616306189
+
+    Args:
+        img: the ee.Image to mask. Must have all the "SR_*" reflectance bands.
+        probability_threshold: pixels above this threshold are included in the mask.
+
+    Returns:
+        the same input image with an updated mask.
+    """
+    # band specifications
+    blue = img.select("SR_B1")
+    green = img.select("SR_B2")
+    red = img.select("SR_B3")
+    nir = img.select("SR_B4")
+    swir1 = img.select("SR_B5")
+    swir2 = img.select("SR_B7")
+
+    # single band thresholds
+    s1 = blue.gt(0.2)
+    s2 = green.gt(0.2)
+    s3 = red.gt(0.21)
+    s4 = swir1.gt(0.29)
+    s5 = swir2.gt(0.25)
+
+    # multi-band thresholds
+    m3 = blue.gt(0.16).And(nir.gt(0.26))
+    m4 = blue.gt(0.20).And(swir1.gt(0.20))
+    m5 = green.gt(0.12).And(nir.gt(0.32))
+    m6 = red.gt(0.14).And(nir.gt(0.35))
+    m7 = nir.gt(0.40).And(swir1.gt(0.30))
+
+    # band ratio
+    ratio = swir1.divide(swir2)
+    ratio_thresh = ratio.gt(0.91).And(ratio.lt(1.83))
+
+    # merge and average the results
+    stack = s1.addBands([s2, s3, s4, s5, m1, m2, m3, m4, m5, m6, m7, ratio_thresh])
+    probability = stack.reduce(ee.Reducer.mean())
+    mask = probability.lt(probability_threshold)
+
+    return img.updateMask(mask)
+
+
+def Landsat8Threshold(img: ee.Image, probability_threshold: float = 0.4) -> ee.Image:
+    """Compute cloud probability using a series of band ratios and apply a mask threshold.
+
+    See Sun & Tian 2017: https://www.sciencedirect.com/science/article/pii/S0924271616306189
+
+    Args:
+        img: the ee.Image to mask. Must have all the "SR_*" reflectance bands.
+        probability_threshold: pixels above this threshold are included in the mask.
+
+    Returns:
+        the same input image with an updated mask.
+    """
+    # band specifications
+    ultrablue = img.select("SR_B1")
+    blue = img.select("SR_B2")
+    green = img.select("SR_B3")
+    red = img.select("SR_B4")
+    nir = img.select("SR_B5")
+    swir1 = img.select("SR_B6")
+    swir2 = img.select("SR_B7")
+
+    # single band thresholds
+    s1 = blue.gt(0.2)
+    s2 = green.gt(0.2)
+    s3 = red.gt(0.21)
+    s4 = swir1.gt(0.29)
+    s5 = swir2.gt(0.25)
+
+    # multi-band thresholds
+    m1 = ultrablue.gt(0.24).And(nir.gt(0.26))
+    m2 = ultrablue.gt(0.24).And(swir1.gt(0.20))
+    m3 = blue.gt(0.16).And(nir.gt(0.26))
+    m4 = blue.gt(0.20).And(swir1.gt(0.20))
+    m5 = green.gt(0.12).And(nir.gt(0.32))
+    m6 = red.gt(0.14).And(nir.gt(0.35))
+    m7 = nir.gt(0.40).And(swir1.gt(0.30))
+
+    # band ratio
+    ratio = swir1.divide(swir2)
+    ratio_thresh = ratio.gt(0.91).And(ratio.lt(1.83))
+
+    # merge and average the results
+    stack = s1.addBands([s2, s3, s4, s5, m1, m2, m3, m4, m5, m6, m7, ratio_thresh])
+    probability = stack.reduce(ee.Reducer.mean())
+    mask = probability.lt(probability_threshold)
+
+    return img.updateMask(mask)
+
+
+def Sentinel2(img: ee.Image, use_qa: bool = True, use_scl: bool = True) -> ee.Image:
+    """Mask Sentinel2 images using multiple masking approaches.
+
+    Args:
+        img: the ee.Image to mask.
+        use_qa: apply QA band cloud masking. img must have a "QA60" band.
+        use_scl: apply SCL band cloud masking. img must have a "SCL" band.
+
+    Returns:
+        the same input image with an updated mask.
+    """
+    if use_qa:
+        img = Sentinel2QA(img)
+
+    if use_scl:
+        img = Sentinel2SCL(img)
+
+    return img
 
 
 def Sentinel2QA(img: ee.Image) -> ee.Image:
@@ -132,27 +291,27 @@ def Sentinel2SCL(img: ee.Image) -> ee.Image:
     return img.updateMask(cloudBareMask)
 
 
-def Sentinel2(img: ee.Image, use_qa: bool = True, use_scl: bool = True) -> ee.Image:
-    """Mask Sentinel2 images using multiple masking approaches.
+def MODIS(img: ee.Image, use_qa: bool = True, use_thresholds: bool = True) -> ee.Image:
+    """Mask MODIS images using multiple masking approaches.
 
     Args:
         img: the ee.Image to mask.
-        use_qa: apply QA band cloud masking. img must have a "QA60" band.
-        use_scl: apply SCL band cloud masking. img must have a "SCL" band.
+        use_qa: apply QA band cloud masking. img must have a "state_1km" band.
+        use_thresholds: apply SCL band cloud masking. img must have a "SCL" band.
 
     Returns:
         the same input image with an updated mask.
     """
     if use_qa:
-        img = Sentinel2QA(img)
+        img = MODISQA(img)
 
-    if use_scl:
-        img = Sentinel2SCL(img)
+    if use_thresholds:
+        img = MODISThreshold(img)
 
     return img
 
 
-def MODIS(img: ee.Image) -> ee.Image:
+def MODISQA(img: ee.Image) -> ee.Image:
     """Mask MODIS images.
 
     Args:
@@ -182,11 +341,74 @@ def MODIS(img: ee.Image) -> ee.Image:
     return img.updateMask(mask)
 
 
-def VIIRS(img: ee.Image) -> ee.Image:
-    """Mask VIIRS images.
+def MODISThreshold(img: ee.Image, probability_threshold: float = 0.6) -> ee.Image:
+    """Compute cloud probability using a series of band ratios and apply a mask threshold.
+
+    See Sun & Tian 2017: https://www.sciencedirect.com/science/article/pii/S0924271616306189
 
     Args:
-        img: the ee.Image to mask. Must have "QF1" and "QF2" bands.
+        img: the ee.Image to mask. Must have all the "sur_refl_b*" reflectance bands.
+        probability_threshold: pixels above this threshold are included in the mask.
+
+    Returns:
+        the same input image with an updated mask.
+    """
+    # band specifications
+    b1 = img.select("sur_refl_b01")
+    b2 = img.select("sur_refl_b02")
+    b3 = img.select("sur_refl_b03")
+    b4 = img.select("sur_refl_b04")
+    b5 = img.select("sur_refl_b05")
+    b6 = img.select("sur_refl_b06")
+    b7 = img.select("sur_refl_b07")
+
+    # single band thresholds
+    s1 = b1.gt(0.29)
+    s2 = b3.gt(0.23)
+    s3 = b4.gt(0.24)
+
+    # multi-band thresholds
+    m1 = b1.gt(0.28).And(b5.gt(0.24))
+    m2 = b1.gt(0.28).And(b6.gt(0.16))
+    m3 = b3.gt(0.28).And(b7.gt(0.08))
+
+    # band ratios
+    ratio = b2.divide(b1)
+    ratio_thresh = ratio.gt(0.95).And(ratio.lt(1.15))
+
+    # merge and average the results
+    stack = s1.addBands([s2, s3, m1, m2, m3, ratio_thresh])
+    probability = stack.reduce(ee.Reducer.mean())
+    mask = probability.lt(probability_threshold)
+
+    return img.updateMask(mask)
+
+
+def VIIRS(img: ee.Image, use_qa: bool = True, use_thresholds: bool = True) -> ee.Image:
+    """Mask VIIRS images using multiple masking approaches.
+
+    Args:
+        img: the ee.Image to mask.
+        use_qa: mask with QA bands.
+        use_thresholds: mask with a series of band thresholds.
+
+    Returns:
+        the same input image with an updated mask.
+    """
+    if use_qa:
+        img = VIIRSQA(img)
+
+    if use_thresholds:
+        img = VIIRSThreshold(img)
+
+    return img
+
+
+def VIIRSQA(img: ee.Image) -> ee.Image:
+    """Mask VIIRS images using QA bands.
+
+    Args:
+        img: the ee.Image to mask. Must have "QF1", "QF2" and "QF7" bands.
 
     Returns:
         the same input image with an updated mask.
@@ -213,6 +435,80 @@ def VIIRS(img: ee.Image) -> ee.Image:
         .And(adjacentMask)
         .And(thinCirrusMask)
     )
+
+    return img.updateMask(mask)
+
+
+def VIIRSThreshold(img: ee.Image, probability_threshold: float = 0.4) -> ee.Image:
+    """Compute cloud probability using a series of band ratios and apply a mask threshold.
+
+    See Sun & Tian 2017: https://www.sciencedirect.com/science/article/pii/S0924271616306189
+
+    Args:
+        img: the ee.Image to mask. Must have all the "M*" reflectance bands.
+        probability_threshold: pixels above this threshold are included in the mask.
+
+    Returns:
+        the same input image with an updated mask.
+    """
+    # band specifications
+    b1 = img.select("M1")
+    b2 = img.select("M2")
+    b3 = img.select("M3")
+    b4 = img.select("M4")
+    b5 = img.select("M5")
+    b6 = img.select("M6")
+    b7 = img.select("M7")
+    b8 = img.select("M8")
+
+    # single band thresholds
+    s1 = b1.gt(0.31)
+    s2 = b2.gt(0.25)
+    s3 = b3.gt(0.25)
+    s4 = b4.gt(0.25)
+    s5 = b5.gt(0.30)
+    s6 = b7.gt(0.52)
+    s7 = b8.gt(0.46)
+
+    # multi-band thresholds
+    m1 = b1.gt(0.29).And(b7.gt(0.30))
+    m2 = b1.gt(0.29).And(b8.gt(0.22))
+    m3 = b1.gt(0.31).And(b10.gt(0.08))
+    m4 = b1.gt(0.29).And(b11.gt(0.12))
+    m5 = b2.gt(0.27).And(b8.gt(0.22))
+    m6 = b2.gt(0.72).And(b10.gt(0.14))
+    m7 = b3.gt(0.23).And(b8.gt(0.24))
+    m8 = b3.gt(0.16).And(b9.gt(0.08))
+
+    # band ratios
+    ratio1 = b6.divide(b4)
+    ratio2 = b7.divide(b5)
+    ratio1_thresh = ratio1.gt(0.12).And(ratio1.lt(0.48))
+    ratio2_thresh = ratio2.gt(1.0).And(ratio2.lt(1.15))
+
+    # merge and average the results
+    stack = s1.addBands(
+        [
+            s2,
+            s3,
+            s4,
+            s5,
+            s6,
+            s7,
+            m1,
+            m2,
+            m3,
+            m4,
+            m5,
+            m6,
+            m7,
+            m8,
+            ratio1_thresh,
+            ratio2_thresh,
+        ]
+    )
+    probability = stack.reduce(ee.Reducer.mean())
+    mask = probability.lt(probability_threshold)
 
     return img.updateMask(mask)
 

--- a/earthlib/CloudMask.py
+++ b/earthlib/CloudMask.py
@@ -34,10 +34,10 @@ def bySensor(sensor: str) -> Callable:
         the mask function associated with a sensor to pass to an ee .map() call
     """
     lookup = {
-        "Landsat4": Landsat457,
-        "Landsat5": Landsat457,
-        "Landsat7": Landsat457,
-        "Landsat8": Landsat8,
+        "Landsat4": Landsat4578,
+        "Landsat5": Landsat4578,
+        "Landsat7": Landsat4578,
+        "Landsat8": Landsat4578,
         "Sentinel2": Sentinel2,
         "MODIS": MODIS,
         "VIIRS": VIIRS,
@@ -52,51 +52,7 @@ def bySensor(sensor: str) -> Callable:
         )
 
 
-def Landsat457(
-    img: ee.Image, use_qa: bool = True, use_thresholds: bool = True
-) -> ee.Image:
-    """Cloud-mask Landsat 4/5/7 images using multiple methods.
-
-    Args:
-        img: the ee.Image to mask.
-        use_qa: mask with the Landsat QA band.
-        use_thresholds: mask with a series of band thresholds.
-
-    Returns:
-        the same input image with an updated mask.
-    """
-    if use_qa:
-        img = Landsat4578QA(img)
-
-    if use_thresholds:
-        img = Landsat457Threshold(img)
-
-    return img
-
-
-def Landsat8(
-    img: ee.Image, use_qa: bool = True, use_thresholds: bool = True
-) -> ee.Image:
-    """Cloud-mask Landsat 8 images using multiple methods.
-
-    Args:
-        img: the ee.Image to mask. Must have a Landsat "QA_PIXEL" band.
-        use_qa: mask with the Landsat QA band.
-        use_thresholds: mask with a series of band thresholds.
-
-    Returns:
-        the same input image with an updated mask.
-    """
-    if use_qa:
-        img = Landsat4578QA(img)
-
-    if use_thresholds:
-        img = Landsat8Threshold(img)
-
-    return img
-
-
-def Landsat4578QA(img: ee.Image) -> ee.Image:
+def Landsat4578(img: ee.Image) -> ee.Image:
     """Cloud-mask Landsat images based on the QA bands.
 
     See https://gis.stackexchange.com/questions/349371/creating-cloud-free-images-out-of-a-mod09a1-modis-image-in-gee
@@ -122,101 +78,6 @@ def Landsat4578QA(img: ee.Image) -> ee.Image:
     jointMask = qaMask.And(satMask)
 
     return img.updateMask(jointMask)
-
-
-def Landsat457Threshold(img: ee.Image, probability_threshold: float = 0.4) -> ee.Image:
-    """Compute cloud probability using a series of band ratios and apply a mask threshold.
-
-    See Sun & Tian 2017: https://www.sciencedirect.com/science/article/pii/S0924271616306189
-
-    Args:
-        img: the ee.Image to mask. Must have all the "SR_*" reflectance bands.
-        probability_threshold: pixels above this threshold are included in the mask.
-
-    Returns:
-        the same input image with an updated mask.
-    """
-    # band specifications
-    blue = img.select("SR_B1")
-    green = img.select("SR_B2")
-    red = img.select("SR_B3")
-    nir = img.select("SR_B4")
-    swir1 = img.select("SR_B5")
-    swir2 = img.select("SR_B7")
-
-    # single band thresholds
-    s1 = blue.gt(0.2)
-    s2 = green.gt(0.2)
-    s3 = red.gt(0.21)
-    s4 = swir1.gt(0.29)
-    s5 = swir2.gt(0.25)
-
-    # multi-band thresholds
-    m3 = blue.gt(0.16).And(nir.gt(0.26))
-    m4 = blue.gt(0.20).And(swir1.gt(0.20))
-    m5 = green.gt(0.12).And(nir.gt(0.32))
-    m6 = red.gt(0.14).And(nir.gt(0.35))
-    m7 = nir.gt(0.40).And(swir1.gt(0.30))
-
-    # band ratio
-    ratio = swir1.divide(swir2)
-    ratio_thresh = ratio.gt(0.91).And(ratio.lt(1.83))
-
-    # merge and average the results
-    stack = s1.addBands([s2, s3, s4, s5, m1, m2, m3, m4, m5, m6, m7, ratio_thresh])
-    probability = stack.reduce(ee.Reducer.mean())
-    mask = probability.lt(probability_threshold)
-
-    return img.updateMask(mask)
-
-
-def Landsat8Threshold(img: ee.Image, probability_threshold: float = 0.4) -> ee.Image:
-    """Compute cloud probability using a series of band ratios and apply a mask threshold.
-
-    See Sun & Tian 2017: https://www.sciencedirect.com/science/article/pii/S0924271616306189
-
-    Args:
-        img: the ee.Image to mask. Must have all the "SR_*" reflectance bands.
-        probability_threshold: pixels above this threshold are included in the mask.
-
-    Returns:
-        the same input image with an updated mask.
-    """
-    # band specifications
-    ultrablue = img.select("SR_B1")
-    blue = img.select("SR_B2")
-    green = img.select("SR_B3")
-    red = img.select("SR_B4")
-    nir = img.select("SR_B5")
-    swir1 = img.select("SR_B6")
-    swir2 = img.select("SR_B7")
-
-    # single band thresholds
-    s1 = blue.gt(0.2)
-    s2 = green.gt(0.2)
-    s3 = red.gt(0.21)
-    s4 = swir1.gt(0.29)
-    s5 = swir2.gt(0.25)
-
-    # multi-band thresholds
-    m1 = ultrablue.gt(0.24).And(nir.gt(0.26))
-    m2 = ultrablue.gt(0.24).And(swir1.gt(0.20))
-    m3 = blue.gt(0.16).And(nir.gt(0.26))
-    m4 = blue.gt(0.20).And(swir1.gt(0.20))
-    m5 = green.gt(0.12).And(nir.gt(0.32))
-    m6 = red.gt(0.14).And(nir.gt(0.35))
-    m7 = nir.gt(0.40).And(swir1.gt(0.30))
-
-    # band ratio
-    ratio = swir1.divide(swir2)
-    ratio_thresh = ratio.gt(0.91).And(ratio.lt(1.83))
-
-    # merge and average the results
-    stack = s1.addBands([s2, s3, s4, s5, m1, m2, m3, m4, m5, m6, m7, ratio_thresh])
-    probability = stack.reduce(ee.Reducer.mean())
-    mask = probability.lt(probability_threshold)
-
-    return img.updateMask(mask)
 
 
 def Sentinel2(img: ee.Image, use_qa: bool = True, use_scl: bool = True) -> ee.Image:
@@ -291,31 +152,11 @@ def Sentinel2SCL(img: ee.Image) -> ee.Image:
     return img.updateMask(cloudBareMask)
 
 
-def MODIS(img: ee.Image, use_qa: bool = True, use_thresholds: bool = True) -> ee.Image:
-    """Mask MODIS images using multiple masking approaches.
+def MODIS(img: ee.Image) -> ee.Image:
+    """Mask MODIS images using the QA band.
 
     Args:
-        img: the ee.Image to mask.
-        use_qa: apply QA band cloud masking. img must have a "state_1km" band.
-        use_thresholds: apply SCL band cloud masking. img must have a "SCL" band.
-
-    Returns:
-        the same input image with an updated mask.
-    """
-    if use_qa:
-        img = MODISQA(img)
-
-    if use_thresholds:
-        img = MODISThreshold(img)
-
-    return img
-
-
-def MODISQA(img: ee.Image) -> ee.Image:
-    """Mask MODIS images.
-
-    Args:
-        img: the ee.Image to mask.
+        img: the ee.Image to mask. Requires a "state_1km" band.
 
     Returns:
         the same input image with an updated mask.
@@ -341,70 +182,7 @@ def MODISQA(img: ee.Image) -> ee.Image:
     return img.updateMask(mask)
 
 
-def MODISThreshold(img: ee.Image, probability_threshold: float = 0.6) -> ee.Image:
-    """Compute cloud probability using a series of band ratios and apply a mask threshold.
-
-    See Sun & Tian 2017: https://www.sciencedirect.com/science/article/pii/S0924271616306189
-
-    Args:
-        img: the ee.Image to mask. Must have all the "sur_refl_b*" reflectance bands.
-        probability_threshold: pixels above this threshold are included in the mask.
-
-    Returns:
-        the same input image with an updated mask.
-    """
-    # band specifications
-    b1 = img.select("sur_refl_b01")
-    b2 = img.select("sur_refl_b02")
-    b3 = img.select("sur_refl_b03")
-    b4 = img.select("sur_refl_b04")
-    b5 = img.select("sur_refl_b05")
-    b6 = img.select("sur_refl_b06")
-    b7 = img.select("sur_refl_b07")
-
-    # single band thresholds
-    s1 = b1.gt(0.29)
-    s2 = b3.gt(0.23)
-    s3 = b4.gt(0.24)
-
-    # multi-band thresholds
-    m1 = b1.gt(0.28).And(b5.gt(0.24))
-    m2 = b1.gt(0.28).And(b6.gt(0.16))
-    m3 = b3.gt(0.28).And(b7.gt(0.08))
-
-    # band ratios
-    ratio = b2.divide(b1)
-    ratio_thresh = ratio.gt(0.95).And(ratio.lt(1.15))
-
-    # merge and average the results
-    stack = s1.addBands([s2, s3, m1, m2, m3, ratio_thresh])
-    probability = stack.reduce(ee.Reducer.mean())
-    mask = probability.lt(probability_threshold)
-
-    return img.updateMask(mask)
-
-
-def VIIRS(img: ee.Image, use_qa: bool = True, use_thresholds: bool = True) -> ee.Image:
-    """Mask VIIRS images using multiple masking approaches.
-
-    Args:
-        img: the ee.Image to mask.
-        use_qa: mask with QA bands.
-        use_thresholds: mask with a series of band thresholds.
-
-    Returns:
-        the same input image with an updated mask.
-    """
-    if use_qa:
-        img = VIIRSQA(img)
-
-    if use_thresholds:
-        img = VIIRSThreshold(img)
-
-    return img
-
-
-def VIIRSQA(img: ee.Image) -> ee.Image:
+def VIIRS(img: ee.Image) -> ee.Image:
     """Mask VIIRS images using QA bands.
 
     Args:
@@ -435,80 +213,6 @@ def VIIRSQA(img: ee.Image) -> ee.Image:
         .And(adjacentMask)
         .And(thinCirrusMask)
     )
-
-    return img.updateMask(mask)
-
-
-def VIIRSThreshold(img: ee.Image, probability_threshold: float = 0.4) -> ee.Image:
-    """Compute cloud probability using a series of band ratios and apply a mask threshold.
-
-    See Sun & Tian 2017: https://www.sciencedirect.com/science/article/pii/S0924271616306189
-
-    Args:
-        img: the ee.Image to mask. Must have all the "M*" reflectance bands.
-        probability_threshold: pixels above this threshold are included in the mask.
-
-    Returns:
-        the same input image with an updated mask.
-    """
-    # band specifications
-    b1 = img.select("M1")
-    b2 = img.select("M2")
-    b3 = img.select("M3")
-    b4 = img.select("M4")
-    b5 = img.select("M5")
-    b6 = img.select("M6")
-    b7 = img.select("M7")
-    b8 = img.select("M8")
-
-    # single band thresholds
-    s1 = b1.gt(0.31)
-    s2 = b2.gt(0.25)
-    s3 = b3.gt(0.25)
-    s4 = b4.gt(0.25)
-    s5 = b5.gt(0.30)
-    s6 = b7.gt(0.52)
-    s7 = b8.gt(0.46)
-
-    # multi-band thresholds
-    m1 = b1.gt(0.29).And(b7.gt(0.30))
-    m2 = b1.gt(0.29).And(b8.gt(0.22))
-    m3 = b1.gt(0.31).And(b10.gt(0.08))
-    m4 = b1.gt(0.29).And(b11.gt(0.12))
-    m5 = b2.gt(0.27).And(b8.gt(0.22))
-    m6 = b2.gt(0.72).And(b10.gt(0.14))
-    m7 = b3.gt(0.23).And(b8.gt(0.24))
-    m8 = b3.gt(0.16).And(b9.gt(0.08))
-
-    # band ratios
-    ratio1 = b6.divide(b4)
-    ratio2 = b7.divide(b5)
-    ratio1_thresh = ratio1.gt(0.12).And(ratio1.lt(0.48))
-    ratio2_thresh = ratio2.gt(1.0).And(ratio2.lt(1.15))
-
-    # merge and average the results
-    stack = s1.addBands(
-        [
-            s2,
-            s3,
-            s4,
-            s5,
-            s6,
-            s7,
-            m1,
-            m2,
-            m3,
-            m4,
-            m5,
-            m6,
-            m7,
-            m8,
-            ratio1_thresh,
-            ratio2_thresh,
-        ]
-    )
-    probability = stack.reduce(ee.Reducer.mean())
-    mask = probability.lt(probability_threshold)
 
     return img.updateMask(mask)
 

--- a/earthlib/ShadeMask.py
+++ b/earthlib/ShadeMask.py
@@ -50,7 +50,7 @@ def shadeMask(img: ee.Image, threshold: float) -> ee.Image:
     return mask
 
 
-def Landsat457(img: ee.Image, threshold: float = 0.03) -> ee.Image:
+def Landsat457(img: ee.Image, threshold: float = 0.045) -> ee.Image:
     """Apply shade masking to a Landsat 4/5/7 image.
 
     Args:
@@ -61,12 +61,15 @@ def Landsat457(img: ee.Image, threshold: float = 0.03) -> ee.Image:
     Returns:
         the same input image with an updated mask.
     """
-    subset = img.select(getBands("Landsat7"))
+    # remove NIR band to ignore multiple scattering
+    bands = getBands("Landsat7")
+    bands.remove("SR_B3")
+    subset = img.select(bands)
     shade = shadeMask(subset, threshold)
     return img.updateMask(shade)
 
 
-def Landsat8(img: ee.Image, threshold: float = 0.03) -> ee.Image:
+def Landsat8(img: ee.Image, threshold: float = 0.045) -> ee.Image:
     """Apply shade masking to a Landsat 8 image.
 
     Args:
@@ -77,12 +80,14 @@ def Landsat8(img: ee.Image, threshold: float = 0.03) -> ee.Image:
     Returns:
         the same input image with an updated mask.
     """
-    subset = img.select(getBands("Landsat8"))
+    bands = getBands("Landsat8")
+    bands.remove("SR_B5")
+    subset = img.select(bands)
     shade = shadeMask(subset, threshold)
     return img.updateMask(shade)
 
 
-def MODIS(img: ee.Image, threshold: float = 0.025) -> ee.Image:
+def MODIS(img: ee.Image, threshold: float = 0.045) -> ee.Image:
     """Apply shade masking to a MODIS image.
 
     Args:
@@ -93,6 +98,9 @@ def MODIS(img: ee.Image, threshold: float = 0.025) -> ee.Image:
     Returns:
         the same input image with an updated mask.
     """
-    subset = img.select(getBands("MODIS"))
+    bands = getBands("MODIS")
+    bands.remove("sur_refl_b02")
+    bands.remove("sur_refl_b05")
+    subset = img.select(bands)
     shade = shadeMask(subset, threshold)
     return img.updateMask(shade)

--- a/earthlib/ShadeMask.py
+++ b/earthlib/ShadeMask.py
@@ -63,7 +63,7 @@ def Landsat457(img: ee.Image, threshold: float = 0.045) -> ee.Image:
     """
     # remove NIR band to ignore multiple scattering
     bands = getBands("Landsat7")
-    bands.remove("SR_B3")
+    bands.remove("SR_B4")
     subset = img.select(bands)
     shade = shadeMask(subset, threshold)
     return img.updateMask(shade)

--- a/earthlib/ThresholdMask.py
+++ b/earthlib/ThresholdMask.py
@@ -1,0 +1,246 @@
+"""Functions for cloud masking earth engine images based on band thresholds."""
+
+from typing import Callable
+
+import ee
+
+from earthlib.errors import SensorError
+
+
+def bySensor(sensor: str) -> Callable:
+    """Returns the appropriate cloud mask function to use by sensor type.
+
+    Args:
+        sensor: string with the sensor name to return (e.g. "Landsat8", "Sentinel2").
+
+    Returns:
+        the mask function associated with a sensor to pass to an ee .map() call
+    """
+    lookup = {
+        "Landsat4": Landsat457,
+        "Landsat5": Landsat457,
+        "Landsat7": Landsat457,
+        "Landsat8": Landsat8,
+        "MODIS": MODIS,
+        "VIIRS": VIIRS,
+    }
+    try:
+        function = lookup[sensor]
+        return function
+    except KeyError:
+        supported = ", ".join(lookup.keys())
+        raise SensorError(
+            f"Cloud masking not supported for '{sensor}'. Supported: {supported}"
+        )
+
+
+def Landsat457(img: ee.Image, probability_threshold: float = 0.4) -> ee.Image:
+    """Compute cloud probability using a series of band ratios and apply a mask threshold.
+
+    See Sun & Tian 2017: https://www.sciencedirect.com/science/article/pii/S0924271616306189
+
+    Args:
+        img: the ee.Image to mask. Must have all the "SR_*" reflectance bands.
+        probability_threshold: pixels above this threshold are included in the mask.
+
+    Returns:
+        the same input image with an updated mask.
+    """
+    # band specifications
+    blue = img.select("SR_B1")
+    green = img.select("SR_B2")
+    red = img.select("SR_B3")
+    nir = img.select("SR_B4")
+    swir1 = img.select("SR_B5")
+    swir2 = img.select("SR_B7")
+
+    # single band thresholds
+    s1 = blue.gt(0.2)
+    s2 = green.gt(0.2)
+    s3 = red.gt(0.21)
+    s4 = swir1.gt(0.29)
+    s5 = swir2.gt(0.25)
+
+    # multi-band thresholds
+    m3 = blue.gt(0.16).And(nir.gt(0.26))
+    m4 = blue.gt(0.20).And(swir1.gt(0.20))
+    m5 = green.gt(0.12).And(nir.gt(0.32))
+    m6 = red.gt(0.14).And(nir.gt(0.35))
+    m7 = nir.gt(0.40).And(swir1.gt(0.30))
+
+    # band ratio
+    ratio = swir1.divide(swir2)
+    ratio_thresh = ratio.gt(0.91).And(ratio.lt(1.83))
+
+    # merge and average the results
+    stack = s1.addBands([s2, s3, s4, s5, m1, m2, m3, m4, m5, m6, m7, ratio_thresh])
+    probability = stack.reduce(ee.Reducer.mean())
+    mask = probability.lt(probability_threshold)
+
+    return img.updateMask(mask)
+
+
+def Landsat8(img: ee.Image, probability_threshold: float = 0.4) -> ee.Image:
+    """Compute cloud probability using a series of band ratios and apply a mask threshold.
+
+    See Sun & Tian 2017: https://www.sciencedirect.com/science/article/pii/S0924271616306189
+
+    Args:
+        img: the ee.Image to mask. Must have all the "SR_*" reflectance bands.
+        probability_threshold: pixels above this threshold are included in the mask.
+
+    Returns:
+        the same input image with an updated mask.
+    """
+    # band specifications
+    ultrablue = img.select("SR_B1")
+    blue = img.select("SR_B2")
+    green = img.select("SR_B3")
+    red = img.select("SR_B4")
+    nir = img.select("SR_B5")
+    swir1 = img.select("SR_B6")
+    swir2 = img.select("SR_B7")
+
+    # single band thresholds
+    s1 = blue.gt(0.2)
+    s2 = green.gt(0.2)
+    s3 = red.gt(0.21)
+    s4 = swir1.gt(0.29)
+    s5 = swir2.gt(0.25)
+
+    # multi-band thresholds
+    m1 = ultrablue.gt(0.24).And(nir.gt(0.26))
+    m2 = ultrablue.gt(0.24).And(swir1.gt(0.20))
+    m3 = blue.gt(0.16).And(nir.gt(0.26))
+    m4 = blue.gt(0.20).And(swir1.gt(0.20))
+    m5 = green.gt(0.12).And(nir.gt(0.32))
+    m6 = red.gt(0.14).And(nir.gt(0.35))
+    m7 = nir.gt(0.40).And(swir1.gt(0.30))
+
+    # band ratio
+    ratio = swir1.divide(swir2)
+    ratio_thresh = ratio.gt(0.91).And(ratio.lt(1.83))
+
+    # merge and average the results
+    stack = s1.addBands([s2, s3, s4, s5, m1, m2, m3, m4, m5, m6, m7, ratio_thresh])
+    probability = stack.reduce(ee.Reducer.mean())
+    mask = probability.lt(probability_threshold)
+
+    return img.updateMask(mask)
+
+
+def MODIS(img: ee.Image, probability_threshold: float = 0.6) -> ee.Image:
+    """Compute cloud probability using a series of band ratios and apply a mask threshold.
+
+    See Sun & Tian 2017: https://www.sciencedirect.com/science/article/pii/S0924271616306189
+
+    Args:
+        img: the ee.Image to mask. Must have all the "sur_refl_b*" reflectance bands.
+        probability_threshold: pixels above this threshold are included in the mask.
+
+    Returns:
+        the same input image with an updated mask.
+    """
+    # band specifications
+    b1 = img.select("sur_refl_b01")
+    b2 = img.select("sur_refl_b02")
+    b3 = img.select("sur_refl_b03")
+    b4 = img.select("sur_refl_b04")
+    b5 = img.select("sur_refl_b05")
+    b6 = img.select("sur_refl_b06")
+    b7 = img.select("sur_refl_b07")
+
+    # single band thresholds
+    s1 = b1.gt(0.29)
+    s2 = b3.gt(0.23)
+    s3 = b4.gt(0.24)
+
+    # multi-band thresholds
+    m1 = b1.gt(0.28).And(b5.gt(0.24))
+    m2 = b1.gt(0.28).And(b6.gt(0.16))
+    m3 = b3.gt(0.28).And(b7.gt(0.08))
+
+    # band ratios
+    ratio = b2.divide(b1)
+    ratio_thresh = ratio.gt(0.95).And(ratio.lt(1.15))
+
+    # merge and average the results
+    stack = s1.addBands([s2, s3, m1, m2, m3, ratio_thresh])
+    probability = stack.reduce(ee.Reducer.mean())
+    mask = probability.lt(probability_threshold)
+
+    return img.updateMask(mask)
+
+
+def VIIRS(img: ee.Image, probability_threshold: float = 0.4) -> ee.Image:
+    """Compute cloud probability using a series of band ratios and apply a mask threshold.
+
+    See Sun & Tian 2017: https://www.sciencedirect.com/science/article/pii/S0924271616306189
+
+    Args:
+        img: the ee.Image to mask. Must have all the "M*" reflectance bands.
+        probability_threshold: pixels above this threshold are included in the mask.
+
+    Returns:
+        the same input image with an updated mask.
+    """
+    # band specifications
+    b1 = img.select("M1")
+    b2 = img.select("M2")
+    b3 = img.select("M3")
+    b4 = img.select("M4")
+    b5 = img.select("M5")
+    b6 = img.select("M6")
+    b7 = img.select("M7")
+    b8 = img.select("M8")
+
+    # single band thresholds
+    s1 = b1.gt(0.31)
+    s2 = b2.gt(0.25)
+    s3 = b3.gt(0.25)
+    s4 = b4.gt(0.25)
+    s5 = b5.gt(0.30)
+    s6 = b7.gt(0.52)
+    s7 = b8.gt(0.46)
+
+    # multi-band thresholds
+    m1 = b1.gt(0.29).And(b7.gt(0.30))
+    m2 = b1.gt(0.29).And(b8.gt(0.22))
+    m3 = b1.gt(0.31).And(b10.gt(0.08))
+    m4 = b1.gt(0.29).And(b11.gt(0.12))
+    m5 = b2.gt(0.27).And(b8.gt(0.22))
+    m6 = b2.gt(0.72).And(b10.gt(0.14))
+    m7 = b3.gt(0.23).And(b8.gt(0.24))
+    m8 = b3.gt(0.16).And(b9.gt(0.08))
+
+    # band ratios
+    ratio1 = b6.divide(b4)
+    ratio2 = b7.divide(b5)
+    ratio1_thresh = ratio1.gt(0.12).And(ratio1.lt(0.48))
+    ratio2_thresh = ratio2.gt(1.0).And(ratio2.lt(1.15))
+
+    # merge and average the results
+    stack = s1.addBands(
+        [
+            s2,
+            s3,
+            s4,
+            s5,
+            s6,
+            s7,
+            m1,
+            m2,
+            m3,
+            m4,
+            m5,
+            m6,
+            m7,
+            m8,
+            ratio1_thresh,
+            ratio2_thresh,
+        ]
+    )
+    probability = stack.reduce(ee.Reducer.mean())
+    mask = probability.lt(probability_threshold)
+
+    return img.updateMask(mask)

--- a/earthlib/__init__.py
+++ b/earthlib/__init__.py
@@ -5,6 +5,7 @@ from earthlib import (
     NIRv,
     Scale,
     ShadeMask,
+    ThresholdMask,
     Unmix,
     __version__,
     read,

--- a/earthlib/utils.py
+++ b/earthlib/utils.py
@@ -1,6 +1,7 @@
 """Utility functions for working with spectral libraries and earth engine routines."""
 
 import os
+from copy import deepcopy as copy
 from warnings import warn
 
 import ee
@@ -106,7 +107,7 @@ def getScaler(sensor: str) -> str:
         scaler: the scale factor to multiply.
     """
     validateSensor(sensor)
-    scaler = collections[sensor]["scale"]
+    scaler = copy(collections[sensor]).get("scale")
     return scaler
 
 
@@ -120,7 +121,7 @@ def getBands(sensor: str) -> list:
         bands: a list of sensor-specific band names.
     """
     validateSensor(sensor)
-    bands = collections[sensor]["band_names"]
+    bands = copy(collections[sensor]).get("band_names")
     return bands
 
 
@@ -134,7 +135,7 @@ def getBandDescriptions(sensor: str) -> list:
         bands: a list of sensor-specific band names.
     """
     validateSensor(sensor)
-    bands = collections[sensor]["band_descriptions"]
+    bands = copy(collections[sensor]).get("band_descriptions")
     return bands
 
 
@@ -149,7 +150,7 @@ def getBandIndices(custom_bands: list, sensor: str) -> list:
         indices: list of integer band indices.
     """
     validateSensor(sensor)
-    sensor_bands = collections[sensor]["band_names"]
+    sensor_bands = getBands(sensor)
     indices = list()
 
     if type(custom_bands) in (list, tuple):


### PR DESCRIPTION
- added a method from [Sun & Tian](https://www.sciencedirect.com/science/article/pii/S0924271616306189) for improved cloud detection via thresholds
- updated bright/shade masking thresholds by removing NIR band from shade calculation, swir2 from bright calculation