### PR TITLE
using modern github actions and python versions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
-      - run: pip install .
+          python-version: 3.11
       - run: pip install mkdocs mkdocs-material mkdocstrings[python] mkdocs-jupyter livereload
+      - run: pip install .
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -9,19 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install poetry
+        run: pipx install poetry
       - name: Python setup
         uses: actions/setup-python@v5
         with:
           python-version: 3.11
-          cache: 'pip'
-      - name: Install package
-        run: |
-          python -m pip install --upgrade pip
-          pip install wheel
-          pip install .
+          cache: 'poetry'
       - name: Build package
         run: |
-          python3 setup.py sdist bdist_wheel
+          poetry build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,0 +1,31 @@
+name: publish-pypi
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Python setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          cache: 'pip'
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel
+          pip install .
+      - name: Build package
+        run: |
+          python3 setup.py sdist bdist_wheel
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: ./dist
+          verbose: true

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -15,14 +15,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.11
-          cache: 'poetry'
       - name: Build package
         run: |
           poetry build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: ./dist
           verbose: true

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -14,14 +14,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
+    - name: Install poetry
+      run: pipx install poetry
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: conda-incubator/setup-miniconda@v2
+    - name: Set up Miniconda
+      uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python-version }}
@@ -34,9 +37,6 @@ jobs:
 
     - name: Install package
       run: |
-        pip install pipx
-        pipx ensurepath
-        pipx install poetry==1.2.0
         make create
       if: steps.cache.outputs.cache-hit != 'true'
     - name: Run pytest

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -17,8 +17,6 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
-    - name: Install poetry
-      run: pipx install poetry
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/earthlib/__init__.py
+++ b/earthlib/__init__.py
@@ -1,3 +1,5 @@
+from importlib.metadata import version as _version
+
 from earthlib import metadata, read, sensors
 from earthlib.endmembers import Spectra, library
 from earthlib.sensors import Sensor, supported_sensors
@@ -18,3 +20,5 @@ try:
     from earthlib.geelib.utils import getCollection
 except ImportError:
     pass
+
+__version__ = _version("earthlib")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "earthlib"
-version = "0.4.0"
+version = "1.0.0"
 description = "A global spectral library with earth engine tools for satellite land cover mapping."
 authors = ["earth-chris <cbanders@alumni.stanford.edu>"]
 license = "MIT"


### PR DESCRIPTION
Docs deployment has been failing because CI was running on an unsupported version of Python.

This MR updates a couple of CI actions to use more modern versions of GitHub Actions, and also updates the number of python versions supported for testing and publishing to pypi.